### PR TITLE
Create 04b_Om_kavene.adoc

### DIFF
--- a/docs/dcat-ap-no/04b_Om_kavene.adoc
+++ b/docs/dcat-ap-no/04b_Om_kavene.adoc
@@ -1,0 +1,20 @@
+== Om kravene i denne standarden [[om-kravene]]
+
+Forklaringen under på ordene «obligatorisk», «anbefalt» og «valgfri», er en fornorsking av tilsvarende forklaring i 
+https://joinup.ec.europa.eu/solution/abr-specification-registry-registries/document/specification-registry-registries-version-100[BRegDCAT-AP] 
+som en utvidelse av DCAT-AP fra EU.
+
+**Klasse:**::
+* **Obligatorisk** (verb: **skal**, **må**): produsent/avsender av data skal oppgi informasjon om instanser av klassen; konsument/mottaker av data skal være i stand til å prosessere informasjon om instanser av klassen. 
+* **Anbefalt** (verb: **bør**): produsent/avsender av data bør oppgi informasjon om instanser av klassen; produsent/avsender av data skal oppgi informasjon om instanser av klassen hvis informasjonen er tilgjengelig; konsument/mottaker av data skal være i sand til å prosessere informasjon om instanser av klassen. 
+* **Valgfri** (verb: **kan**): produsent/avsender av data kan oppgi informasjon om instanser av klassen, men det er ikke påkrevd; konsument/mottaker av data skal være i stand til å prosessere informasjon om instanser av klassen.  
+
+
+**Egenskap:**::
+* **Obligatorisk** (verb: **skal**, **må**): produsent/avsender av data skal oppgi informasjonen for egenskapen; konsument/mottaker av data skal være i stand til å prosessere informasjonen for egenskapen. 
+* **Anbefalt** (verb: **bør**): produsent/avsender av data bør oppgi informasjonen for egenskapen hvis informasjonen er tilgjengelig; konsument/mottaker av data skal være i stand til å prosessere informasjonen for egenskapen.  
+* **Valgfri** (verb: **kan**): produsent/avsender av data kan oppgi informasjonen for egenskapen, men det er ikke påkrevd; konsument/mottaker av data skal være i stand til å prosessere informasjonen for egenskapen.  
+
+I konteksten datadeling og datautveksling, betyr det «å prosessere» at konsument/mottaker aksepterer innkommende data og transparent videreformidler dataene til aktuelle applikasjoner og tjenester. 
+
+Betydningen av ordene «skal» (engelsk: shall), «må» (engelsk: must), «bør» (engelsk: should) og «kan» (engelsk: may) er i samsvar med https://tools.ietf.org/html/rfc2119[RFC 2119]. 


### PR DESCRIPTION
Oppretter et nytt kapittel med forklaring på "obligatorisk", "anbefalt" og "valgfri" (#44). Som egen adoc-fil slik at den ved behov kan gjenbrukes / refereres til i andre sammenhenger.  

Kapittelet/filen bør inkluderes mellom nåværende 04_... og 05_...,  i main.adoc