### PR TITLE
Update 04b_Om_kravene.adoc

### DIFF
--- a/docs/dcat-ap-no/04b_Om_kravene.adoc
+++ b/docs/dcat-ap-no/04b_Om_kravene.adoc
@@ -4,13 +4,13 @@ Forklaringen under på ordene «obligatorisk», «anbefalt» og «valgfri», er 
 https://joinup.ec.europa.eu/solution/abr-specification-registry-registries/document/specification-registry-registries-version-100[BRegDCAT-AP] 
 som en utvidelse av DCAT-AP fra EU.
 
-**Klasse:**::
+Klasse::
 * **Obligatorisk** (verb: **skal**, **må**): produsent/avsender av data skal oppgi informasjon om instanser av klassen; konsument/mottaker av data skal være i stand til å prosessere informasjon om instanser av klassen. 
 * **Anbefalt** (verb: **bør**): produsent/avsender av data bør oppgi informasjon om instanser av klassen; produsent/avsender av data skal oppgi informasjon om instanser av klassen hvis informasjonen er tilgjengelig; konsument/mottaker av data skal være i sand til å prosessere informasjon om instanser av klassen. 
 * **Valgfri** (verb: **kan**): produsent/avsender av data kan oppgi informasjon om instanser av klassen, men det er ikke påkrevd; konsument/mottaker av data skal være i stand til å prosessere informasjon om instanser av klassen.  
 
 
-**Egenskap:**::
+Egenskap::
 * **Obligatorisk** (verb: **skal**, **må**): produsent/avsender av data skal oppgi informasjonen for egenskapen; konsument/mottaker av data skal være i stand til å prosessere informasjonen for egenskapen. 
 * **Anbefalt** (verb: **bør**): produsent/avsender av data bør oppgi informasjonen for egenskapen hvis informasjonen er tilgjengelig; konsument/mottaker av data skal være i stand til å prosessere informasjonen for egenskapen.  
 * **Valgfri** (verb: **kan**): produsent/avsender av data kan oppgi informasjonen for egenskapen, men det er ikke påkrevd; konsument/mottaker av data skal være i stand til å prosessere informasjonen for egenskapen.  


### PR DESCRIPTION
Aha, det var kommentar på bold som ikke er nødvendig for \<term\> i \<description list\>, som nå er rettet opp